### PR TITLE
fix #34. deparse may return multiple strings if input is too long; wr…

### DIFF
--- a/R/LDSearch.R
+++ b/R/LDSearch.R
@@ -115,7 +115,7 @@ LDSearch <- function(SNPs,
                       GeneCruiser=TRUE,
                       quiet=FALSE, ...) {
 
-  if (grepl("LDSearch", deparse(sys.call()))) {
+  if (grepl("LDSearch", paste(deparse(sys.call()), collapse = ""))) {
     .Deprecated("ld_search", package = "rsnps",
       "use ld_search instead - LDSearch removed in next version")
   }


### PR DESCRIPTION
…apping it in paste keeps it nicely in one string.