### PR TITLE
replaced unit test for allphenotypes

### DIFF
--- a/tests/testthat/test-allphenotypes.R
+++ b/tests/testthat/test-allphenotypes.R
@@ -22,6 +22,7 @@ test_that("allphenotypes returns the correct value", {
 })
 
 test_that("allphenotypes returns set of common known_variations (common = in more than 5 individuals)", {
+    skip_on_cran()
   
     expect_true(all(c("False", "True", "Undiagnosed, but probably true", "No", "Yes", 
                     "Not diagnosed", "Mthfr c677t") %in% as.character(allphenotypes()[["ADHD"]][,3]))) 

--- a/tests/testthat/test-allphenotypes.R
+++ b/tests/testthat/test-allphenotypes.R
@@ -13,13 +13,6 @@ test_that("allphenotypes returns the correct dims for data.frame", {
 	expect_that(ncol(allphenotypes()[["ADHD"]]), equals(4))
 })
 
-test_that("allphenotypes returns the correct value", {
-  # test failed, because known variations for ADHD phenotypes were probably updated
-  #	skip_on_cran()
-
-  #	expect_that(as.character(allphenotypes()[["ADHD"]][7,3]),
-  #							equals("Mthfr c677t"))
-})
 
 test_that("allphenotypes returns set of common known_variations (common = in more than 5 individuals)", {
     skip_on_cran()

--- a/tests/testthat/test-allphenotypes.R
+++ b/tests/testthat/test-allphenotypes.R
@@ -14,8 +14,16 @@ test_that("allphenotypes returns the correct dims for data.frame", {
 })
 
 test_that("allphenotypes returns the correct value", {
-	skip_on_cran()
+  # test failed, because known variations for ADHD phenotypes were probably updated
+  #	skip_on_cran()
 
-	expect_that(as.character(allphenotypes()[["ADHD"]][7,3]),
-							equals("Mthfr c677t"))
+  #	expect_that(as.character(allphenotypes()[["ADHD"]][7,3]),
+  #							equals("Mthfr c677t"))
+})
+
+test_that("allphenotypes returns set of common known_variations (common = in more than 5 individuals)", {
+  
+    expect_true(all(c("False", "True", "Undiagnosed, but probably true", "No", "Yes", 
+                    "Not diagnosed", "Mthfr c677t") %in% as.character(allphenotypes()[["ADHD"]][,3]))) 
+  
 })


### PR DESCRIPTION
Third unit test in `tests/testthat/test-allphenotypes.R` did not pass. 

## Description

This unit test for allphenotypes **failed** because the `known_variation` `"Mthfr c677t"` is now on row 8 and not 7. 
```
test_that("allphenotypes returns the correct value", {
  skip_on_cran()

  expect_that(as.character(allphenotypes()[["ADHD"]][7,3]),
  							equals("Mthfr c677t"))
})
```
Tried to understand the mechanism by which the allphenotypes() table is generated, see [here](https://github.com/ropensci/rsnps/issues/72#issuecomment-491829054). For example, a new user could have mixed this table. We cannot really tell for sure with the information we have available. 

Replaced the unit test with: 

```
test_that("allphenotypes returns set of common known_variations (common = in more than 5 individuals)", {
  
    expect_true(all(c("False", "True", "Undiagnosed, but probably true", "No", "Yes", 
                    "Not diagnosed", "Mthfr c677t") %in% as.character(allphenotypes()[["ADHD"]][,3]))) 
  
})
```
Instead of testing a specific row, we are now testing we are now testing whether previously common variations are included. 

## Related Issue
#72 
