### PR TITLE
Fix order of output of ncbi_snp_query to have Chromosome and BP besid…

### DIFF
--- a/R/NCBI_snp_query.R
+++ b/R/NCBI_snp_query.R
@@ -129,8 +129,8 @@ ncbi_snp_query <- function(SNPs, key = NULL, ...) {
   SNPs <- SNPs[ SNPs %in% found_snps ]
 
   out <- as.data.frame(matrix(0, nrow = length(SNPs), ncol = 11))
-  names(out) <- c("Query", "Chromosome", "Marker", "Class", "Gene", "Alleles",
-    "Major", "Minor", "MAF", "BP", "AncestralAllele")
+  names(out) <- c("Query", "Chromosome", "BP", "Marker", "Class", "Gene", "Alleles",
+    "Major", "Minor", "MAF", "AncestralAllele")
 
   for (i in seq_along(SNPs)) {
     my_list <- xml_list[[i]]
@@ -209,10 +209,10 @@ ncbi_snp_query <- function(SNPs, key = NULL, ...) {
     anc_all <- if (is.na(anc_all)) NA else anc_all[[1]]
 
     out[i, ] <- c(
-      SNPs[i], my_chr, my_snp, unname(my_snpClass),
+      SNPs[i], my_chr, as.integer(my_pos), my_snp, unname(my_snpClass),
       unname(my_gene), paste0(unname(alleles), collapse = ","), 
       unname(my_major), unname(my_minor),
-      as.numeric(my_freq), as.integer(my_pos),
+      as.numeric(my_freq), 
       anc_all
     )
   }

--- a/tests/testthat/test-NCBI_snp_query.R
+++ b/tests/testthat/test-NCBI_snp_query.R
@@ -9,8 +9,8 @@ test_that("ncbi_snp_query works", {
   expect_is(aa$Query, "character")
   expect_is(aa$Chromosome, "character")
   expect_type(aa$BP, "double")
-  expect_named(aa, c('Query', 'Chromosome', 'Marker', 'Class', 'Gene',
-                'Alleles', 'Major', 'Minor', 'MAF', 'BP', 'AncestralAllele'))
+  expect_named(aa, c('Query', 'Chromosome', 'BP', 'Marker', 'Class', 'Gene',
+                'Alleles', 'Major', 'Minor', 'MAF', 'AncestralAllele'))
 })
 
 test_that("ncbi_snp_query - many snps at once works", {
@@ -23,8 +23,8 @@ test_that("ncbi_snp_query - many snps at once works", {
   expect_is(aa$Query, "character")
   expect_is(aa$Chromosome, "character")
   expect_type(aa$BP, "double")
-  expect_named(aa, c('Query', 'Chromosome', 'Marker', 'Class', 'Gene',
-              'Alleles', 'Major', 'Minor', 'MAF', 'BP', 'AncestralAllele'))
+  expect_named(aa, c('Query', 'Chromosome', 'BP', 'Marker', 'Class', 'Gene',
+              'Alleles', 'Major', 'Minor', 'MAF', 'AncestralAllele'))
   expect_gt(NROW(aa), 2)
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reorder data frame output from NCBI_snp_query.R so that Chromosome and BP are beside each other. 

## Related Issue
fix #70 

