### PR TITLE
Added the use of Rtools to appveyor yaml 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ init:
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 
+environment:
+  USE_RTOOLS: true
+
 install:
   ps: Bootstrap
 


### PR DESCRIPTION
Added the use of Rtools to appveyor yaml so that compiled package mime can be properly built.  As described by @sinarueeger, Rtools is needed for packages need to be compiled on Windows OS. 

Related Issue
Fix  #81