### PR TITLE
T71 sugg sckott

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,4 +22,4 @@ opening an issue or contacting one or more of the project maintainers.
 
 This Code of Conduct is adapted from the Contributor Covenant 
 (http:contributor-covenant.org), version 1.0.0, available at 
-http://contributor-covenant.org/version/1/0/0/
+https://contributor-covenant.org/version/1/0/0/

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2018
-COPYRIGHT HOLDER: Scott Chamberlain
+YEAR: 2019
+COPYRIGHT HOLDER: Julia Gustavsen, Sina Rüeger

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,3 @@
-# rsnps 0.3.2
 
 rsnps 0.3.2
 ===========
@@ -16,10 +15,6 @@ rsnps 0.3.2
 ### BUG FIXES
 
 * Fixed the test for `allphenotypes` function by making it less specific (#72). 
-
-
-rsnps 0.3.1
-===========
 
 
 rsnps 0.3.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -97,7 +97,7 @@ For more detail, see the [vignette: rsnps tutorial](https://github.com/ropensci/
 * Please [report any issues or bugs](https://github.com/ropensci/rsnps/issues).
 * License: MIT
 * Get citation information for `rsnsps` in R doing `citation(package = 'rsnps')`
-* Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
+* Please note that this project is released with a [Contributor Code of Conduct](https://github.com/ropensci/rsnps/blob/dev/CODE_OF_CONDUCT.md). 
 By participating in this project you agree to abide by its terms.
 
 [![ropensci_footer](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/README.md
+++ b/README.md
@@ -71,16 +71,10 @@ SNPs <- c("rs332", "rs420358", "rs1837253", "rs1209415715", "rs111068718")
 ncbi_snp_query(SNPs)
 ```
 
-    #>          Query Chromosome       Marker  Class Gene Alleles Major Minor
-    #> 1        rs332          7  rs121909001 in-del CFTR   -/TTT  <NA>  <NA>
-    #> 2     rs420358          1     rs420358    snp CFTR   A,G,T     A     G
-    #> 3    rs1837253          5    rs1837253    snp CFTR     C/T     C     T
-    #> 4 rs1209415715          9 rs1209415715    snp CFTR     C,T     C     T
-    #>      MAF        BP AncestralAllele
-    #> 1     NA 117559593            <NA>
-    #> 2     NA 117559593     T,T,T,T,T,T
-    #> 3 0.3822 117559593     T,T,T,T,T,T
-    #> 4     NA 117559593            <NA>
+    #>  [1] Query           Chromosome      BP              Marker         
+    #>  [5] Class           Gene            Alleles         Major          
+    #>  [9] Minor           MAF             AncestralAllele
+    #> <0 rows> (or 0-length row.names)
 
 ### openSNP data
 
@@ -124,8 +118,9 @@ tutorial](https://github.com/ropensci/rsnps/blob/master/inst/vign/rsnps_vignette
   - Get citation information for `rsnsps` in R doing `citation(package =
     'rsnps')`
   - Please note that this project is released with a [Contributor Code
-    of Conduct](CODE_OF_CONDUCT.md). By participating in this project
-    you agree to abide by its
+    of
+    Conduct](https://github.com/ropensci/rsnps/blob/dev/CODE_OF_CONDUCT.md).
+    By participating in this project you agree to abide by its
 terms.
 
 [![ropensci\_footer](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,14 +10,14 @@
   "codeRepository": "https://github.com/ropensci/rsnps",
   "issueTracker": "https://github.com/ropensci/rsnps/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.3.1.9113",
+  "version": "0.3.2.9121",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.5.2",
+    "version": "3.5.1",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.5.2 Patched (2018-12-31 r75943)",
+  "runtimePlatform": "R version 3.5.1 (2018-07-02)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -27,9 +27,22 @@
   "author": [
     {
       "@type": "Person",
+      "givenName": "Julia",
+      "familyName": "Gustavsen",
+      "email": "j.gustavsen@gmail.com",
+      "@id": "https://orcid.org/0000-0002-4764-4802"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Sina",
+      "familyName": "Rüeger",
+      "email": "sina.rueeger@gmail.com",
+      "@id": "https://orcid.org/0000-0003-2848-9242"
+    },
+    {
+      "@type": "Person",
       "givenName": "Scott",
       "familyName": "Chamberlain",
-      "email": "myrmecocystus@gmail.com",
       "@id": "https://orcid.org/0000-0003-1444-9135"
     },
     {
@@ -46,10 +59,10 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": "Scott",
-      "familyName": "Chamberlain",
-      "email": "myrmecocystus@gmail.com",
-      "@id": "https://orcid.org/0000-0003-1444-9135"
+      "givenName": "Julia",
+      "familyName": "Gustavsen",
+      "email": "j.gustavsen@gmail.com",
+      "@id": "https://orcid.org/0000-0002-4764-4802"
     }
   ],
   "softwareSuggestions": [
@@ -170,10 +183,13 @@
   "keywords": ["gene", "snp", "sequence", "API", "web", "api-client", "species", "dbSNP", "OpenSNP", "NCBI", "genotype", "web-api", "snps", "data", "rstats", "r", "r-package"],
   "releaseNotes": "https://github.com/ropensci/rsnps/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/rsnps/blob/master/README.md",
-  "fileSize": "37.101KB",
+  "fileSize": "37.352KB",
   "contIntegration": [
     "https://travis-ci.org/ropensci/rsnps",
     "https://ci.appveyor.com/project/sckott/rsnps/branch/master",
     "https://codecov.io/github/ropensci/rsnps?branch=master"
-  ]
+  ],
+  "contributor": {},
+  "copyrightHolder": {},
+  "funder": {}
 }


### PR DESCRIPTION
Implementing small changes as suggested by @sckott.

## Description

- `CODE_OF_CONDUCT.md`: fixed the broken link at the bottom: http:// to https://.
- `LICENSE`: Upgraded to `2019` and changed holder to `Julia Gustavsen, Sina Rüeger` (could not find an example with more than one person, not sure if its `and` or `,`)
- `NEWS.md`: removed empty and duplicated header
- Ran `codemetar::write_codemeta(".")`
- `README.Rmd`: replaced relative links with absolute ones (for link COC file), then re-knitted the file. 


## Related Issue
#71

