### PR TITLE
Adding new tests for ncbi_snp_query()

### DIFF
--- a/tests/testthat/test-NCBI_snp_query.R
+++ b/tests/testthat/test-NCBI_snp_query.R
@@ -43,6 +43,46 @@ test_that("ncbi_snp_query for rs1610720 (multiple alleles)", {
   
 })
 
+test_that("ncbi_snp_query for rs146107628 (duplication)", {
+  ## truth: https://www.ncbi.nlm.nih.gov/snp/rs146107628
+  skip_on_cran()
+  
+  aa <- ncbi_snp_query("rs146107628")
+  
+  
+  expect_equal(aa$Chromosome, "10")
+  expect_equal(aa$BP, 98243085) ## on GRCh38
+  expect_equal(aa$Marker, "rs146107628")
+  expect_equal(aa$Class, "insertion")
+  expect_equal(aa$Gene, "R3HCC1L")
+  expect_equal(aa$Alleles, "T")
+  expect_equal(aa$Major, "T")
+  expect_equal(aa$Minor, "TT")
+  expect_equal(aa$MAF, 0.0365)
+  expect_equal(aa$AncestralAllele, "T")
+  
+})
+
+test_that("ncbi_snp_query for rs200623867 (deletion)", {
+  ## truth: https://www.ncbi.nlm.nih.gov/snp/rs200623867
+  skip_on_cran()
+  
+  aa <- ncbi_snp_query("rs200623867")
+  
+  
+  expect_equal(aa$Chromosome, "10")
+  expect_equal(aa$BP, 98243545) ## on GRCh38
+  expect_equal(aa$Marker, "rs200623867")
+  expect_equal(aa$Class, "deletion")
+  expect_equal(aa$Gene, "R3HCC1L")
+  expect_equal(aa$Alleles, "G")
+  expect_equal(aa$Major, "G")
+  expect_equal(aa$Minor, "-")
+  expect_equal(aa$MAF, NA)
+  expect_equal(aa$AncestralAllele, "G")
+  
+})
+
 test_that("ncbi_snp_query works", {
   skip_on_cran()
 

--- a/tests/testthat/test-NCBI_snp_query.R
+++ b/tests/testthat/test-NCBI_snp_query.R
@@ -1,5 +1,25 @@
 context("ncbi_snp_query")
 
+test_that("ncbi_snp_query for rs1421085", {
+  skip_on_cran()
+  
+  aa <- ncbi_snp_query("rs1421085")
+  
+  
+  expect_equal(aa$Chromosome, "16")
+  expect_equal(aa$BP, 53767042) ## on GRCh38
+  expect_equal(aa$Marker, "rs1421085")
+  expect_equal(aa$Class, "snv")
+  expect_equal(aa$Gene, "FTO")
+  expect_equal(aa$Alleles, "T,C")
+  expect_equal(aa$Major, "T")
+  expect_equal(aa$Minor, "C")
+  expect_equal(aa$MAF, 0.3161)
+  expect_equal(aa$AncestralAllele, "T")
+  
+})
+
+
 test_that("ncbi_snp_query works", {
   skip_on_cran()
 

--- a/tests/testthat/test-NCBI_snp_query.R
+++ b/tests/testthat/test-NCBI_snp_query.R
@@ -1,6 +1,8 @@
 context("ncbi_snp_query")
 
 test_that("ncbi_snp_query for rs1421085", {
+  ## truth: https://www.ncbi.nlm.nih.gov/snp/?term=rs1421085
+  
   skip_on_cran()
   
   aa <- ncbi_snp_query("rs1421085")
@@ -19,6 +21,27 @@ test_that("ncbi_snp_query for rs1421085", {
   
 })
 
+
+test_that("ncbi_snp_query for rs1610720 (multiple alleles)", {
+  ## from issue59: https://github.com/ropensci/rsnps/issues/59
+  ## truth: https://www.ncbi.nlm.nih.gov/snp/?term=rs1610720
+  skip_on_cran()
+  
+  aa <- ncbi_snp_query("rs1610720")
+  
+  
+  expect_equal(aa$Chromosome, "6")
+  expect_equal(aa$BP, 29793285) ## on GRCh38
+  expect_equal(aa$Marker, "rs1610720")
+  expect_equal(aa$Class, "snv")
+  expect_equal(aa$Gene, "HCG4/HLA-V")
+  expect_equal(aa$Alleles, "A,G,T")
+  expect_equal(aa$Major, "A")
+  expect_equal(aa$Minor, "G,T")
+  expect_equal(aa$MAF, 0.3895)
+  expect_equal(aa$AncestralAllele, "A")
+  
+})
 
 test_that("ncbi_snp_query works", {
   skip_on_cran()

--- a/tests/testthat/test-NCBI_snp_query.R
+++ b/tests/testthat/test-NCBI_snp_query.R
@@ -53,7 +53,7 @@ test_that("ncbi_snp_query for rs146107628 (duplication)", {
   expect_equal(aa$Chromosome, "10")
   expect_equal(aa$BP, 98243085) ## on GRCh38
   expect_equal(aa$Marker, "rs146107628")
-  expect_equal(aa$Class, "insertion")
+  expect_equal(aa$Class, "indel")
   expect_equal(aa$Gene, "R3HCC1L")
   expect_equal(aa$Alleles, "T")
   expect_equal(aa$Major, "T")
@@ -73,7 +73,7 @@ test_that("ncbi_snp_query for rs200623867 (deletion)", {
   expect_equal(aa$Chromosome, "10")
   expect_equal(aa$BP, 98243545) ## on GRCh38
   expect_equal(aa$Marker, "rs200623867")
-  expect_equal(aa$Class, "deletion")
+  expect_equal(aa$Class, "indel")
   expect_equal(aa$Gene, "R3HCC1L")
   expect_equal(aa$Alleles, "G")
   expect_equal(aa$Major, "G")
@@ -82,6 +82,28 @@ test_that("ncbi_snp_query for rs200623867 (deletion)", {
   expect_equal(aa$AncestralAllele, "G")
   
 })
+
+
+test_that("ncbi_snp_query for rs1799752 (deletion)", {
+  ## truth: https://www.ncbi.nlm.nih.gov/snp/rs1799752
+  skip_on_cran()
+  
+  aa <- ncbi_snp_query("rs1799752")
+  
+  
+  expect_equal(aa$Chromosome, "17")
+  expect_equal(aa$BP, 63488530) ## on GRCh38 :63488530-63488543
+  expect_equal(aa$Marker, "rs1799752")
+  expect_equal(aa$Class, "indel")
+  expect_equal(aa$Gene, "ACE")
+  expect_equal(aa$Alleles, "ATACAGTCACTTTT,ATACAGTCACTTTTTTTTTTTTTTTGAGACGGAGTCTCGCTCTGTCGCCCATACAGTCACTTTT")
+  expect_equal(aa$Major, "ATACAGTCACTTTT")
+  expect_equal(aa$Minor, "ATACAGTCACTTTTTTTTTTTTTTTGAGACGGAGTCTCGCTCTGTCGCCCATACAGTCACTTTT")
+  expect_equal(aa$MAF, NA)
+  expect_equal(aa$AncestralAllele, "ATACAGTCACTTTT")
+  
+})
+
 
 test_that("ncbi_snp_query works", {
   skip_on_cran()


### PR DESCRIPTION
Added five specific unit tests for `ncbi_snp_query()`: 
- one simple rsid
- the rsid that was failing previously (#59)
- two short indels
- a larger indel

These tests might need to be corrected. For example, the rsid `rs1610720` has two genes and three alleles. So not sure how we are gonna handle that. 

But they might be useful for testing a new ncbi function.

## Related Issue
#59  + #86 

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
