### PR TITLE
Description suggests update 102

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Imports:
     httr
 Suggests:
     testthat,
-    knitr
+    knitr,
+    markdown
 RoxygenNote: 7.1.0
 X-schema.org-applicationCategory: Genes
 X-schema.org-keywords: gene, snp, sequence, API, web, api-client, species, dbSNP, OpenSNP, NCBI, genotype


### PR DESCRIPTION
This fixes a missing dependency seen when running `devtools::check_win_devel()` as part of the checks in issue #102. This adds {markdown} to suggests in the description (as suggested here: https://win-builder.r-project.org/iUiM5i0dzCRa/00check.log

