### PR TITLE
fix https, web address changes and missing trailing slashes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rsnps
 Title: Get 'SNP' ('Single-Nucleotide' 'Polymorphism') Data on the Web
 Description: A programmatic interface to various 'SNP' 'datasets'
     on the web: 'OpenSNP' (<https://opensnp.org>), and 'NBCIs' 'dbSNP' database
-    (<https://www.ncbi.nlm.nih.gov/projects/SNP>). Functions
+    (<https://www.ncbi.nlm.nih.gov/projects/SNP/>). Functions
     are included for searching for 'NCBI'. For 'OpenSNP', functions are included 
     for getting 'SNPs', and data for 'genotypes', 'phenotypes', annotations, 
     and bulk downloads of data by user.
@@ -20,8 +20,8 @@ Authors@R: c(
     person("Kevin", "Ushey", role = "aut"),
     person("Hao", "Zhu", role = "aut")
     )
-URL: https://docs.ropensci.org/rsnps, https://github.com/ropensci/rsnps
-BugReports: https://github.com/ropensci/rsnps/issues
+URL: https://docs.ropensci.org/rsnps/, https://github.com/ropensci/rsnps/
+BugReports: https://github.com/ropensci/rsnps/issues/
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/ncbi_snp_api.R
+++ b/R/ncbi_snp_api.R
@@ -152,7 +152,7 @@ get_gene_names <- function(primary_info) {
 #' has been merged, the up-to-date name of the ID is returned here, and
 #' a warning is issued.
 #' - class: The rsid's 'class'. See
-#' <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass>
+#' <https://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass>
 #' for more details.
 #' - gene: If the rsid lies within a gene (either within the exon
 #' or introns of a gene), the name of that gene is returned here; otherwise,
@@ -175,7 +175,7 @@ get_gene_names <- function(primary_info) {
 #'
 #'
 #' @references <https://www.ncbi.nlm.nih.gov/projects/SNP/>
-#' @references <https://www.ncbi.nlm.nih.gov/pubmed/31738401> SPDI model
+#' @references <https://pubmed.ncbi.nlm.nih.gov/31738401/> SPDI model
 #'
 #' @details Note that you are limited in the to a max of one query per second
 #' and concurrent queries are not allowed.

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,12 +14,12 @@ knitr::opts_chunk$set(
 )
 ```
 
-[![cran checks](https://cranchecks.info/badges/worst/rsnps)](https://cranchecks.info/pkgs/rsnps)
-[![Build Status](https://api.travis-ci.org/ropensci/rsnps.png)](https://travis-ci.org/ropensci/rsnps)
-[![Build status](https://ci.appveyor.com/api/projects/status/d2lv98726u6t9ut5/branch/master)](https://ci.appveyor.com/project/sckott/rsnps/branch/master)
+[![cran checks](https://cranchecks.info/badges/worst/rsnps)](https://cranchecks.info/pkgs/rsnps/)
+[![Build Status](https://api.travis-ci.org/ropensci/rsnps.png)](https://travis-ci.org/ropensci/rsnps/)
+[![Build status](https://ci.appveyor.com/api/projects/status/d2lv98726u6t9ut5/branch/master)](https://ci.appveyor.com/project/sckott/rsnps/branch/master/)
 [![codecov.io](https://codecov.io/github/ropensci/rsnps/coverage.svg?branch=master)](https://codecov.io/github/ropensci/rsnps?branch=master)
 [![cran version](https://www.r-pkg.org/badges/version/rsnps)](https://cran.r-project.org/package=rsnps)
-[![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/rsnps?color=E664A4)](https://github.com/metacran/cranlogs.app)
+[![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/rsnps?color=E664A4)](https://github.com/r-hub/cranlogs.app)
 
 This package gives you access to data from OpenSNP and NCBI's dbSNP SNP database.
 
@@ -35,13 +35,13 @@ This set of functions/package accesses data from:
 + openSNP.org
 	+ <https://opensnp.org>
 	+ See documentation on the openSNP API <https://opensnp.org/faq#api>
-	+ See blog post about their API <https://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints>
+	+ See blog post about their API <https://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints/>
 	+ Relevant functions:
 		+ `allgensnp()`, `allphenotypes()`, `annotations()`, `download_users()`, 
 		`fetch_genotypes()`, `genotypes()`, `phenotypes()`, `phenotypes_byid()`, `users()`
 
 + NCBI's dbSNP SNP database
-	+ See <https://www.ncbi.nlm.nih.gov/snp> for more details
+	+ See <https://www.ncbi.nlm.nih.gov/snp/> for more details
 	+ Relevant function:
 		+ `ncbi_snp_query()`
 
@@ -92,7 +92,7 @@ For more detail, see the [vignette: rsnps tutorial](https://github.com/ropensci/
 
 ## Meta
 
-* Please [report any issues or bugs](https://github.com/ropensci/rsnps/issues).
+* Please [report any issues or bugs](https://github.com/ropensci/rsnps/issues/).
 * License: MIT
 * Get citation information for `rsnsps` in R doing `citation(package = 'rsnps')`
 * Please note that this package is released with a [Contributor Code of Conduct](https://ropensci.org/code-of-conduct/). By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 # rsnps
 
 [![cran
-checks](https://cranchecks.info/badges/worst/rsnps)](https://cranchecks.info/pkgs/rsnps)
+checks](https://cranchecks.info/badges/worst/rsnps)](https://cranchecks.info/pkgs/rsnps/)
 [![Build
-Status](https://api.travis-ci.org/ropensci/rsnps.png)](https://travis-ci.org/ropensci/rsnps)
+Status](https://api.travis-ci.org/ropensci/rsnps.png)](https://travis-ci.org/ropensci/rsnps/)
 [![Build
-status](https://ci.appveyor.com/api/projects/status/d2lv98726u6t9ut5/branch/master)](https://ci.appveyor.com/project/sckott/rsnps/branch/master)
+status](https://ci.appveyor.com/api/projects/status/d2lv98726u6t9ut5/branch/master)](https://ci.appveyor.com/project/sckott/rsnps/branch/master/)
 [![codecov.io](https://codecov.io/github/ropensci/rsnps/coverage.svg?branch=master)](https://codecov.io/github/ropensci/rsnps?branch=master)
 [![cran
-version](http://www.r-pkg.org/badges/version/rsnps)](https://cran.r-project.org/package=rsnps)
+version](https://www.r-pkg.org/badges/version/rsnps)](https://cran.r-project.org/package=rsnps)
 [![rstudio mirror
-downloads](http://cranlogs.r-pkg.org/badges/rsnps?color=E664A4)](https://github.com/metacran/cranlogs.app)
+downloads](https://cranlogs.r-pkg.org/badges/rsnps?color=E664A4)](https://github.com/r-hub/cranlogs.app)
 
 This package gives you access to data from OpenSNP and NCBI’s dbSNP SNP
 database.
@@ -31,13 +31,13 @@ This set of functions/package accesses data from:
       - See documentation on the openSNP API
         <https://opensnp.org/faq#api>
       - See blog post about their API
-        <http://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints>
+        <https://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints/>
       - Relevant functions:
           - `allgensnp()`, `allphenotypes()`, `annotations()`,
             `download_users()`, `fetch_genotypes()`, `genotypes()`,
             `phenotypes()`, `phenotypes_byid()`, `users()`
   - NCBI’s dbSNP SNP database
-      - See <https://www.ncbi.nlm.nih.gov/snp> for more details
+      - See <https://www.ncbi.nlm.nih.gov/snp/> for more details
       - Relevant function:
           - `ncbi_snp_query()`
 
@@ -52,8 +52,8 @@ install.packages("rsnps")
 Or dev version
 
 ``` r
-install.packages("devtools")
-devtools::install_github("ropensci/rsnps")
+install.packages("remotes")
+remotes::install_github("ropensci/rsnps")
 ```
 
 ``` r
@@ -69,22 +69,22 @@ snps <- c("rs332", "rs420358", "rs1837253", "rs1209415715", "rs111068718")
 ncbi_snp_query(snps)
 ```
 
-    #>          Query Chromosome        BP Class         rsid          Gene
+    #>          query chromosome        bp class         rsid          gene
     #> 1        rs332          7 117559593   del  rs121909001 CFTR/CFTR-AS1
     #> 2     rs420358          1  40341239   snv     rs420358              
     #> 3    rs1837253          5 111066174   snv    rs1837253              
     #> 4 rs1209415715          9  41782316   snv rs1209415715              
-    #>       Alleles AncestralAllele VariationAllele      seqname
-    #> 1 TTT, delTTT             TTT          delTTT NC_000007.14
-    #> 2     A,C,G,T               A           C,G,T NC_000001.11
-    #> 3         T,C               T               C NC_000005.10
-    #> 4         T,C               T               C NC_000009.12
+    #>       alleles ancestral_allele variation_allele      seqname
+    #> 1 TTT, delTTT              TTT           delTTT NC_000007.14
+    #> 2     A,C,G,T                A            C,G,T NC_000001.11
+    #> 3         T,C                T                C NC_000005.10
+    #> 4         T,C                T                C NC_000009.12
     #>                                                                               hgvs
     #> 1                                            NC_000007.14:g.117559593_117559595del
     #> 2 NC_000001.11:g.40341239A>C,NC_000001.11:g.40341239A>G,NC_000001.11:g.40341239A>T
     #> 3                                                      NC_000005.10:g.111066174T>C
     #> 4                                                       NC_000009.12:g.41782316T>C
-    #>     assembly ref_seq Minor    MAF
+    #>     assembly ref_seq minor    maf
     #> 1 GRCh38.p12    <NA>  <NA>     NA
     #> 2 GRCh38.p12       A     C 0.8614
     #> 3 GRCh38.p12       T     C 0.7133
@@ -92,8 +92,7 @@ ncbi_snp_query(snps)
 
 ### openSNP data
 
-`genotypes()`
-    function
+`genotypes()` function
 
 ``` r
 genotypes('rs9939609', userid='1,6,8', df=TRUE)
@@ -127,13 +126,12 @@ tutorial](https://github.com/ropensci/rsnps/blob/master/inst/vign/rsnps_vignette
 ## Meta
 
   - Please [report any issues or
-    bugs](https://github.com/ropensci/rsnps/issues).
+    bugs](https://github.com/ropensci/rsnps/issues/).
   - License: MIT
   - Get citation information for `rsnsps` in R doing `citation(package =
     'rsnps')`
   - Please note that this package is released with a [Contributor Code
     of Conduct](https://ropensci.org/code-of-conduct/). By contributing
-    to this project, you agree to abide by its
-terms.
+    to this project, you agree to abide by its terms.
 
 [![ropensci\_footer](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,34 +19,6 @@ Old maintainer(s):
   
  This is an expected change as the maintainers of this package have changed. 
  
-* Also noted in win-builder were the following changes where we updated to https from http:
-
-Found the following (possibly) invalid URLs:
-  URL: http://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints (moved to https://opensnp.wordpress.com/2012/01/18/some-progress-on-the-api-json-endpoints/)
-    From: README.md
-    Status: 200
-    Message: OK
-  URL: http://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass (moved to https://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass)
-    From: man/ncbi_snp_query.Rd
-    Status: 200
-    Message: OK
-  URL: https://github.com/metacran/cranlogs.app (moved to https://github.com/r-hub/cranlogs.app)
-    From: README.md
-    Status: 200
-    Message: OK
-  URL: https://www.ncbi.nlm.nih.gov/projects/SNP (moved to https://www.ncbi.nlm.nih.gov/projects/SNP/)
-    From: DESCRIPTION
-    Status: 200
-    Message: OK
-  URL: https://www.ncbi.nlm.nih.gov/pubmed/31738401 (moved to https://pubmed.ncbi.nlm.nih.gov/31738401/)
-    From: man/ncbi_snp_query.Rd
-    Status: 200
-    Message: OK
-  URL: https://www.ncbi.nlm.nih.gov/snp (moved to https://www.ncbi.nlm.nih.gov/snp/)
-    From: README.md
-    Status: 200
-    Message: OK
-  
 ## Reverse dependencies
 
 * We have run R CMD check on the 1 downstream dependency

--- a/man/ncbi_snp_query.Rd
+++ b/man/ncbi_snp_query.Rd
@@ -22,7 +22,7 @@ what the dbSNP website has.
 has been merged, the up-to-date name of the ID is returned here, and
 a warning is issued.
 \item class: The rsid's 'class'. See
-\url{http://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass}
+\url{https://www.ncbi.nlm.nih.gov/projects/SNP/snp_legend.cgi?legend=snpClass}
 for more details.
 \item gene: If the rsid lies within a gene (either within the exon
 or introns of a gene), the name of that gene is returned here; otherwise,
@@ -81,5 +81,5 @@ ncbi_snp_query("rs121909001", verbose = TRUE)
 \references{
 \url{https://www.ncbi.nlm.nih.gov/projects/SNP/}
 
-\url{https://www.ncbi.nlm.nih.gov/pubmed/31738401} SPDI model
+\url{https://pubmed.ncbi.nlm.nih.gov/31738401/} SPDI model
 }


### PR DESCRIPTION
Hi @sinarueeger ,

It turns out that the problems found in winbuilder could be fixed by changing and modifying some of the web addresses. This PR now gives us a clean winbuilder: https://win-builder.r-project.org/5ziCpnj0vi8c/00check.log (with just the one note about the maintainer). 
I would like to merge here to master so that we can re-submit again quickly. 

Thanks, Julia