### PR TITLE
Github issue templates (2nd attempt)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve rsnps
+title: ''
+labels: 'Bug'
+assignees: ''
+
+---
+
+**Please do not submit bug reports for issues with the OpenSNP or NCBI’s dbSNP server itself. rsnps is only an API client, it does not have control over the server hosting the data.**
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Code to reproduce**
+A clear set of code illustrating the steps to reproduce the behaviour.
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**OS and R versions (please complete the following information):**
+ - OS: [e.g., Windows10, macOS, Linux]
+ - R Version [e.g., 3.6.2]
+
+**Session Info: `devtools::session_info()` or `sessionInfo()`**
+
+<details> <summary><strong>Session Info</strong></summary>
+  
+```r
+
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for rsnps
+title: ''
+labels: 'Feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,8 +1,0 @@
-<!-- If this issue relates to usage of the package, whether a question, bug or similar, along with your query, please paste your devtools::session_info() or sessionInfo() into the code block below. If not, delete all this and proceed :) -->
-
-<details> <summary><strong>Session Info</strong></summary>
-
-```r
-
-```
-</details>


### PR DESCRIPTION
@jooolia we don't get tons of issues, but some of them are questions about the capacity of rsnps or questions about genetic variants. 

I was thinking of adding issue templates for bugs and features, borrowed the idea from these two repositories:

- https://github.com/ropensci/nasapower/tree/master/.github/ISSUE_TEMPLATE
- https://github.com/ropensci/targets/tree/main/.github/ISSUE_TEMPLATE