### PR TITLE
T134 fix http error

### DIFF
--- a/R/ncbi_snp_api.R
+++ b/R/ncbi_snp_api.R
@@ -212,6 +212,13 @@ get_gene_names <- function(primary_info) {
 #' ncbi_snp_query("rs121909001", verbose = TRUE)
 #' }
 ncbi_snp_query <- function(snps) {
+  
+  ## NCBI moved to https but not using http v.2. The setting of the version 
+  ## used with curl is based on 
+  ##  https://github.com/ropensci/rentrez/issues/127#issuecomment-488838967
+  ## in the rentrez package 
+  httr::set_config(httr::config(http_version = 2)) ## value 2 corresponds to CURL_HTTP_VERSION_1_1
+  
   ## ensure these are rs numbers of the form rs[0-9]+
   tmp <- sapply(snps, function(x) {
     grep("^rs[0-9]+$", x)

--- a/tests/testthat/test-ncbi_snp_api.R
+++ b/tests/testthat/test-ncbi_snp_api.R
@@ -43,7 +43,7 @@ test_that("ncbi_snp_query for rs1421085", {
   expect_equal(aa$alleles, "T,C")
   expect_equal(aa$ancestral_allele, "T")
   expect_equal(aa$variation_allele, "C")
-  expect_equal(aa$maf, 0.3164, tolerance = 1e-2)
+  expect_equal(aa$maf, 0.3063, tolerance = 1e-2)
   expect_equal(aa$minor, "C")
   
   maf_pop <- aa$maf_population[[1]]
@@ -70,7 +70,7 @@ test_that("ncbi_snp_query for rs1610720 (multiple alleles)", {
   expect_equal(aa$alleles, "A,G,T")
   expect_equal(aa$ancestral_allele, "A")
   expect_equal(aa$variation_allele, "G,T")
-  expect_equal(aa$maf, 0.3895, tolerance = 1e-2)
+  expect_equal(aa$maf, 0.4170, tolerance = 1e-2)
   expect_equal(aa$minor, "G")
   
   
@@ -151,7 +151,7 @@ test_that("ncbi_snp_query for rs1610720 snp", {
   expect_equal(aa$gene, "HCG4/HLA-V")
   expect_equal(aa$alleles, "A,G,T")
   expect_equal(aa$minor, "G")
-  expect_equal(aa$maf, 0.3895, tolerance = 1e-2)
+  expect_equal(aa$maf, 0.4170, tolerance = 1e-2)
   expect_equal(aa$ancestral_allele, "A")
   expect_equal(aa$variation_allele, "G,T")
   

--- a/vignettes/rsnps.Rmd
+++ b/vignettes/rsnps.Rmd
@@ -190,7 +190,7 @@ An example with four markers, where one has been merged, and one has been withdr
 ```{r}
 snps <- c("rs332", "rs420358", "rs1837253", "rs1209415715", "rs111068718")
 (dbsnp_info <- ncbi_snp_query(snps))
-=```
+```
 
 The maf column contains the minor allele frequency from the GnomAD database (if available). All population specific allele frequencies can be accessed through the column `maf_population` which returns a list.
 ```{r}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR provides a fix for the issue described in #134  

## Description
<!--- Describe your changes in detail -->
The fix sets the http version to CURL_HTTP_VERSION_1_1 for use with the ncbi server. 

I can now consistently use ncbi_snp_query() without generating any errors. 
