### PR TITLE
T67 fix name duplication in allgensnp()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     knitr,
     markdown,
     tibble
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 X-schema.org-applicationCategory: Genes
 X-schema.org-keywords: gene, snp, sequence, API, web, api-client, species, dbSNP, OpenSNP, NCBI, genotype
 X-schema.org-isPartOf: https://ropensci.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+rsnps 0.5.0.9000 (dev - to be bumped upon release)
+===========
+
+### MINOR IMPROVEMENTS
+
+* allgensnp(): previously the dataframe returned contained duplicate "name" columns. 
+Now the "name" column that contains the submitter's name has been renamed "user_name"
+and the snp rsid name remains "name".
+
+
 rsnps 0.5.0
 ===========
 

--- a/R/allgensnp.R
+++ b/R/allgensnp.R
@@ -19,7 +19,9 @@ allgensnp <- function(snp = NA, ...) {
     us_er$genotypes <- NULL
     us_er <- c(us_er, unlist(z$user$genotypes, FALSE))
     user <- data.frame(us_er, stringsAsFactors = FALSE)
-    cbind(snp, us_er)
+    ## snp data frame also has a column called "name"
+    names(user)[names(user) == "name"] <- "user_name"
+    cbind(snp, user)
   }))
 }
 

--- a/man/allgensnp.Rd
+++ b/man/allgensnp.Rd
@@ -19,7 +19,7 @@ Get openSNP genotype data for all users at a particular snp.
 }
 \examples{
 \dontrun{
-x <- allgensnp(snp = 'rs7412')
+x <- allgensnp(snp = "rs7412")
 head(x)
 }
 }

--- a/tests/testthat/test-allgensnp.R
+++ b/tests/testthat/test-allgensnp.R
@@ -1,0 +1,16 @@
+# tests for allphenotypes fxn in ropensnp
+context("allgensnp")
+
+test_that("allphenotypes returns the correct class", {
+  skip_on_cran()
+  
+  dat <- allgensnp(snp = "rs486907")
+  expect_equal(sum(c("name",
+                     "chromosome",
+                     "position",
+                     "user_name",
+                     "id",
+                     "genotype_id",
+                     "local_genotype") %in% colnames(dat)),
+               length(colnames(dat)))
+})


### PR DESCRIPTION

## Description

allgensnp(): previously the dataframe returned contained duplicate "name" columns. 
Now the "name" column that contains the submitter's name has been renamed "user_name"
and the snp rsid name remains "name".


## Related Issue
#67



