### PR TITLE
Fix failure and add warning message for unsupported snp

### DIFF
--- a/R/ncbi_snp_api.R
+++ b/R/ncbi_snp_api.R
@@ -294,6 +294,15 @@ ncbi_snp_query <- function(snps) {
       )
       next()
     }
+    
+    if ("unsupported_snapshot_data" %in% names(variant.response.content) & length(variant.response.content$present_obs_movements) == 0) {
+      warning("The following rsId no longer has any supporting observations in NCBI:\n  ",
+              paste0("rs", snps_num[i]),
+              call. = FALSE
+      )
+      next()
+    }
+    
     Query <- as.character(paste0("rs", variant.response.content$refsnp_id))
 
     ## if merged into another id

--- a/tests/testthat/test-ncbi_snp_api.R
+++ b/tests/testthat/test-ncbi_snp_api.R
@@ -211,3 +211,18 @@ test_that("ncbi_snp_query fails well", {
   expect_error(ncbi_snp_query(5), "not all items supplied are prefixed")
   expect_error(ncbi_snp_query("ab5"), "not all items supplied are prefixed")
 })
+
+
+
+test_that("ncbi_snp_query handles unsupported snps well", {
+  skip_on_cran()
+  ## from issue *157
+  expect_warning(aa <- ncbi_snp_query("rs10921627"), "The following rsId no longer has any supporting observations in NCBI:
+  rs10921627")
+
+  # Among other supported SNPs:
+  expect_warning(aa <- ncbi_snp_query(c( "rs10921647", "rs10921627", "rs10921645" )),"The following rsId no longer has any supporting observations in NCBI:
+  rs10921627")
+  expect_is(aa, "data.frame")
+
+})


### PR DESCRIPTION
## Description
Adds support for the case where supporting observations for a dbsnp entry have been removed from dbsnp database. A new set of tests have been added using an example snp mentioned in #157. 

## Related Issue
#157 

## Example
Now `ncbi_snp_query("rs10921627").` returns : "The following rsId no longer has any supporting observations in NCBI:
  rs10921627"


